### PR TITLE
Use `nonroot` as our default example.

### DIFF
--- a/.apko.yaml
+++ b/.apko.yaml
@@ -4,3 +4,12 @@ contents:
   packages:
     - ca-certificates-bundle
     - alpine-baselayout-data
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+  run-as: 65532


### PR DESCRIPTION
This adds a user block that makes the default user consistent with distroless' `nonroot` user.

By including this in the template, the hope is that we will encourage more folks to treat running as nonroot as the baseline, vs. something they have to find and configure themselves.

See also: https://github.com/distroless/static/pull/1