### PR TITLE
Post to slack on failures.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,9 @@ on:
 
 name: Create Release
 
+# Don't run multiple releases concurrently.
+concurrency: release
+
 jobs:
   build:
     name: Release OCI image
@@ -24,3 +27,17 @@ jobs:
       with:
         config: .apko.yaml
         base-tag: ghcr.io/${{ github.repository }}
+
+    # Post to slack when things fail.
+    - if: ${{ failure() }}
+      uses: rtCamp/action-slack-notify@v2.2.0
+      env:
+        SLACK_ICON: http://github.com/chainguardian.png?size=48
+        SLACK_USERNAME: chainguardian
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        SLACK_CHANNEL: distroless
+        SLACK_COLOR: '#8E1600'
+        MSG_MINIMAL: 'true'
+        SLACK_TITLE: Releasing ${{ github.repository }} failed.
+        SLACK_MESSAGE: |
+          For detailed logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
This adds a slack action to post to our slack instance when releases fail, so we get visibility into them.

I also noticed we didn't set concurrency, so multiple releases could kick off concurrently, and this corrects that.

I've configured an org-level `SLACK_WEBHOOK` secret, so all of our repos should be ready for this.